### PR TITLE
🧹 Add Material Icon Theme configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "bierner.markdown-mermaid",
     "biomejs.biome",
     "clinyong.vscode-css-modules",
+    "material-extensions.vscode-material-icon-theme",
     "vitest.explorer"
   ],
   "unwantedRecommendations": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,36 @@
 
   // === Spelling ===
   "cSpell.ignoreWords": ["bindtap", "testid"],
-  "cSpell.words": ["bindconfirm"]
+  "cSpell.words": ["bindconfirm"],
+
+  // === Material Icon Theme ===
+  "material-icon-theme.activeIconPack": "react",
+  "material-icon-theme.saturation": 0.9,
+  "material-icon-theme.opacity": 0.9,
+  "material-icon-theme.files.associations": {
+    "*.claudeignore": "claude",
+    "__root.tsx": "routing",
+    "__route-tree.gen.ts": "routing"
+  },
+  "material-icon-theme.folders.customClones": [
+    {
+      "name": "deepsource-rules",
+      "base": "rules",
+      "color": "#43a047",
+      "folderNames": ["deepsource"]
+    }
+  ],
+  "material-icon-theme.folders.associations": {
+    "agents": "admin",
+    "autopilot": "robot",
+    "cart": "",
+    "deepsource": "rules",
+    "entities": "element",
+    "forge": "forgejo",
+    "home": "",
+    "progress": "tasks",
+    "screens": "desktop",
+    "skills": "bicep",
+    "validate": "resolver"
+  }
 }


### PR DESCRIPTION
## Description

Add VS Code Material Icon Theme configuration for better visual navigation of the project structure. Includes custom folder icon associations, file icon associations, a custom color clone for the deepsource folder, and adding the extension to recommended extensions list.

## Type of change

- Update (chore) (documentation, packages, or tests updates, nothing that affects the end user directly)

## Related Issues

- Closes #50

## Notes

- Configured folder icons: entities → element, screens → desktop, skills → bicep, agents → admin, etc.
- Added file associations for routing files (`__root.tsx`, `__route-tree.gen.ts`)
- Custom color clone for deepsource folder using resolver green (`#43a047`)
- React icon pack enabled, saturation and opacity set to 0.9

## Check list

- [x] I have performed a self-review of my code
- [x] My code follows the project's coding style and conventions
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation (if applicable)